### PR TITLE
feat: (partially) test aliases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/aliasing/test*.py" = ["S101"]
+"tests/aliasing/test*.py" = ["S101", "FBT001"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/tests/aliasing/conftest.py
+++ b/tests/aliasing/conftest.py
@@ -1,0 +1,91 @@
+import pytest
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+
+
+@pytest.fixture
+def model_with_plain_alias():
+    class ModelWithPlainAlias(BaseModel):
+        first_name: str = Field(alias="firstName")
+
+    return ModelWithPlainAlias
+
+
+@pytest.fixture
+def model_with_serialization_alias():
+    class ModelWithSerializationAlias(BaseModel):
+        first_name: str = Field(serialization_alias="f_name")
+
+    return ModelWithSerializationAlias
+
+
+@pytest.fixture
+def model_with_validation_alias():
+    class ModelWithValidationAlias(BaseModel):
+        first_name: str = Field(validation_alias="firstName")
+
+    return ModelWithValidationAlias
+
+
+@pytest.fixture
+def model_with_validation_alias_choices():
+    class ModelWithValidationAliasChoices(BaseModel):
+        first_name: str = Field(validation_alias=AliasChoices("firstName", "givenName", "preferredName"))
+
+    return ModelWithValidationAliasChoices
+
+
+@pytest.fixture
+def model_with_validation_alias_path():
+    class ModelWithValidationAliasPath(BaseModel):
+        pass
+
+
+@pytest.fixture
+def model_with_plain_and_serialization_alias():
+    class ModelWithPlainAndSerializationAlias(BaseModel):
+        first_name: str = Field(alias="firstName", serialization_alias="f_name")
+
+    return ModelWithPlainAndSerializationAlias
+
+
+@pytest.fixture
+def model_with_plain_and_validation_alias():
+    class ModelWithPlainAndValidationAlias(BaseModel):
+        first_name: str = Field(alias="f_name", validation_alias="firstName")
+
+    return ModelWithPlainAndValidationAlias
+
+
+@pytest.fixture
+def model_with_plain_and_serialization_and_validation_alias():
+    class ModelWithPlainAndSerializationAndValidationAlias(BaseModel):
+        first_name: str = Field(alias="f_name_a", serialization_alias="f_name_s", validation_alias="firstName")
+
+    return ModelWithPlainAndSerializationAndValidationAlias
+
+
+@pytest.fixture
+def model_with_plain_alias_and_pop_by_name_config():
+    class ModelWithPlainAliasPopByName(BaseModel):
+        model_config = ConfigDict(populate_by_name=True)
+        first_name: str = Field(alias="firstName")
+
+    return ModelWithPlainAliasPopByName
+
+
+@pytest.fixture
+def model_with_serialization_alias_and_pop_by_name_config():
+    class ModelWithSerializationAliasPopByName(BaseModel):
+        model_config = ConfigDict(populate_by_name=True)
+        first_name: str = Field(serialization_alias="f_name")
+
+    return ModelWithSerializationAliasPopByName
+
+
+@pytest.fixture
+def model_with_validation_alias_and_pop_by_name_config():
+    class ModelWithValidationAliasPopByName(BaseModel):
+        model_config = ConfigDict(populate_by_name=True)
+        first_name: str = Field(validation_alias="firstName")
+
+    return ModelWithValidationAliasPopByName

--- a/tests/aliasing/test_combination_aliases.py
+++ b/tests/aliasing/test_combination_aliases.py
@@ -14,15 +14,22 @@ class TestPlainAndSerializationAlias:
                 "f_name",
                 "Mickey",
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'f_name': 'Mickey'}}],
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
             (
                 "first_name",
                 "Mickey",
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'first_name': 'Mickey'}}],
-            )
-        ]
+                [
+                    {
+                        "type": "missing",
+                        "loc": ("firstName",),
+                        "msg": "Field required",
+                        "input": {"first_name": "Mickey"},
+                    }
+                ],
+            ),
+        ],
     )
     def test_should_instantiate_model_fields_by_plain_alias(
         self,
@@ -30,7 +37,7 @@ class TestPlainAndSerializationAlias:
         arg_name: str,
         arg_value: str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             _ = model_with_plain_and_serialization_alias(**{arg_name: arg_value})
@@ -40,7 +47,6 @@ class TestPlainAndSerializationAlias:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
 
-
     @pytest.mark.parametrize(
         "data, expectation, expected_error",
         [
@@ -49,31 +55,45 @@ class TestPlainAndSerializationAlias:
             (
                 {"f_name": "Mickey"},
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
             (
                 '{"f_name": "Mickey"}',
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
             (
                 {"first_name": "Mickey"},
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'first_name': 'Mickey'}}]
+                [
+                    {
+                        "type": "missing",
+                        "loc": ("firstName",),
+                        "msg": "Field required",
+                        "input": {"first_name": "Mickey"},
+                    }
+                ],
             ),
             (
                 '{"first_name": "Mickey"}',
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'first_name': 'Mickey'}}]
+                [
+                    {
+                        "type": "missing",
+                        "loc": ("firstName",),
+                        "msg": "Field required",
+                        "input": {"first_name": "Mickey"},
+                    }
+                ],
             ),
-        ]
+        ],
     )
     def test_should_deserialize_by_plain_alias(
         self,
         model_with_plain_and_serialization_alias,
         data: dict | str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             if isinstance(data, dict):
@@ -86,7 +106,6 @@ class TestPlainAndSerializationAlias:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
 
-
     def test_serialize_by_field_name(self, model_with_plain_and_serialization_alias):
         model = model_with_plain_and_serialization_alias(firstName="Mickey")
         assert model.model_dump() == {"first_name": "Mickey"}
@@ -95,7 +114,6 @@ class TestPlainAndSerializationAlias:
         assert model.model_dump_json() != '{"f_name":"Mickey"}'
         assert model.model_dump() != {"firstName": "Mickey"}
         assert model.model_dump_json() != '{"firstName":"Mickey"}'
-
 
     def test_serialize_by_serialization_alias(self, model_with_plain_and_serialization_alias):
         model = model_with_plain_and_serialization_alias(firstName="Mickey")
@@ -106,7 +124,6 @@ class TestPlainAndSerializationAlias:
         assert model.model_dump(by_alias=True) != {"firstName": "Mickey"}
         assert model.model_dump_json(by_alias=True) != '{"firstName":"Mickey"}'
 
-
     def test_should_repr_by_field_name(self, model_with_plain_and_serialization_alias):
         model = model_with_plain_and_serialization_alias(firstName="Mickey")
         assert repr(model).find("first_name") > -1
@@ -114,20 +131,9 @@ class TestPlainAndSerializationAlias:
         assert repr(model).find("firstName") == -1
         assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
 
-
-    @pytest.mark.parametrize(
-        "arg_name, expected",
-        [
-            ("first_name", True),
-            ("f_name", False),
-            ("firstName", False)
-        ]
-    )
+    @pytest.mark.parametrize("arg_name, expected", [("first_name", True), ("f_name", False), ("firstName", False)])
     def test_should_class_attribute_have_field_name(
-        self,
-        model_with_plain_and_serialization_alias,
-        arg_name: str,
-        expected: bool
+        self, model_with_plain_and_serialization_alias, arg_name: str, expected: bool
     ):
         model = model_with_plain_and_serialization_alias(firstName="Mickey")
         assert hasattr(model, arg_name) is expected
@@ -143,15 +149,22 @@ class TestPlainAndValidationAlias:
                 "f_name",
                 "Mickey",
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'f_name': 'Mickey'}}],
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
             (
                 "first_name",
                 "Mickey",
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'first_name': 'Mickey'}}],
-            )
-        ]
+                [
+                    {
+                        "type": "missing",
+                        "loc": ("firstName",),
+                        "msg": "Field required",
+                        "input": {"first_name": "Mickey"},
+                    }
+                ],
+            ),
+        ],
     )
     def test_should_instantiate_model_fields_by_validation_alias(
         self,
@@ -159,7 +172,7 @@ class TestPlainAndValidationAlias:
         arg_name: str,
         arg_value: str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             _ = model_with_plain_and_validation_alias(**{arg_name: arg_value})
@@ -169,7 +182,6 @@ class TestPlainAndValidationAlias:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
 
-
     @pytest.mark.parametrize(
         "data, expectation, expected_error",
         [
@@ -178,31 +190,45 @@ class TestPlainAndValidationAlias:
             (
                 {"f_name": "Mickey"},
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
             (
                 '{"f_name": "Mickey"}',
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
             (
                 {"first_name": "Mickey"},
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'first_name': 'Mickey'}}]
+                [
+                    {
+                        "type": "missing",
+                        "loc": ("firstName",),
+                        "msg": "Field required",
+                        "input": {"first_name": "Mickey"},
+                    }
+                ],
             ),
             (
                 '{"first_name": "Mickey"}',
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'first_name': 'Mickey'}}]
+                [
+                    {
+                        "type": "missing",
+                        "loc": ("firstName",),
+                        "msg": "Field required",
+                        "input": {"first_name": "Mickey"},
+                    }
+                ],
             ),
-        ]
+        ],
     )
     def test_should_deserialize_by_validation_alias(
         self,
         model_with_plain_and_validation_alias,
         data: dict | str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             if isinstance(data, dict):
@@ -215,7 +241,6 @@ class TestPlainAndValidationAlias:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
 
-
     def test_serialize_by_field_name(self, model_with_plain_and_validation_alias):
         model = model_with_plain_and_validation_alias(firstName="Mickey")
         assert model.model_dump() == {"first_name": "Mickey"}
@@ -225,14 +250,12 @@ class TestPlainAndValidationAlias:
         assert model.model_dump() != {"firstName": "Mickey"}
         assert model.model_dump_json() != '{"firstName":"Mickey"}'
 
-
     def test_serialize_by_serialization_alias(self, model_with_plain_and_validation_alias):
         model = model_with_plain_and_validation_alias(firstName="Mickey")
         assert model.model_dump(by_alias=True) == {"f_name": "Mickey"}
         assert model.model_dump_json(by_alias=True) == '{"f_name":"Mickey"}'
         assert model.model_dump(by_alias=True) != {"firstName": "Mickey"}
         assert model.model_dump_json(by_alias=True) != '{"firstName":"Mickey"}'
-
 
     def test_should_repr_by_field_name(self, model_with_plain_and_validation_alias):
         model = model_with_plain_and_validation_alias(firstName="Mickey")
@@ -241,20 +264,9 @@ class TestPlainAndValidationAlias:
         assert repr(model).find("firstName") == -1
         assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
 
-
-    @pytest.mark.parametrize(
-        "arg_name, expected",
-        [
-            ("first_name", True),
-            ("f_name", False),
-            ("firstName", False)
-        ]
-    )
+    @pytest.mark.parametrize("arg_name, expected", [("first_name", True), ("f_name", False), ("firstName", False)])
     def test_should_class_attribute_have_field_name(
-        self,
-        model_with_plain_and_validation_alias,
-        arg_name: str,
-        expected: bool
+        self, model_with_plain_and_validation_alias, arg_name: str, expected: bool
     ):
         model = model_with_plain_and_validation_alias(firstName="Mickey")
         assert hasattr(model, arg_name) is expected
@@ -270,15 +282,15 @@ class TestPlainAndSerializationAndValidationAlias:
                 "f_name_a",
                 "Mickey",
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'f_name_a': 'Mickey'}}],
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name_a": "Mickey"}}],
             ),
             (
                 "f_name_s",
                 "Mickey",
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'f_name_s': 'Mickey'}}],
-            )
-        ]
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name_s": "Mickey"}}],
+            ),
+        ],
     )
     def test_should_instantiate_model_fields_by_validation_alias(
         self,
@@ -286,7 +298,7 @@ class TestPlainAndSerializationAndValidationAlias:
         arg_name: str,
         arg_value: str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             _ = model_with_plain_and_serialization_and_validation_alias(**{arg_name: arg_value})
@@ -296,7 +308,6 @@ class TestPlainAndSerializationAndValidationAlias:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
 
-
     @pytest.mark.parametrize(
         "data, expectation, expected_error",
         [
@@ -305,31 +316,31 @@ class TestPlainAndSerializationAndValidationAlias:
             (
                 {"f_name_a": "Mickey"},
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name_a': 'Mickey'}}]
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name_a": "Mickey"}}],
             ),
             (
                 '{"f_name_a": "Mickey"}',
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name_a': 'Mickey'}}]
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name_a": "Mickey"}}],
             ),
             (
                 {"f_name_s": "Mickey"},
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name_s': 'Mickey'}}]
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name_s": "Mickey"}}],
             ),
             (
                 '{"f_name_s": "Mickey"}',
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name_s': 'Mickey'}}]
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name_s": "Mickey"}}],
             ),
-        ]
+        ],
     )
     def test_should_deserialize_by_validation_alias(
         self,
         model_with_plain_and_serialization_and_validation_alias,
         data: dict | str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             if isinstance(data, dict):
@@ -342,7 +353,6 @@ class TestPlainAndSerializationAndValidationAlias:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
 
-
     def test_serialize_by_field_name(self, model_with_plain_and_serialization_and_validation_alias):
         model = model_with_plain_and_serialization_and_validation_alias(firstName="Mickey")
         assert model.model_dump() == {"first_name": "Mickey"}
@@ -354,7 +364,6 @@ class TestPlainAndSerializationAndValidationAlias:
         assert model.model_dump() != {"firstName": "Mickey"}
         assert model.model_dump_json() != '{"firstName":"Mickey"}'
 
-
     def test_serialize_by_serialization_alias(self, model_with_plain_and_serialization_and_validation_alias):
         model = model_with_plain_and_serialization_and_validation_alias(firstName="Mickey")
         assert model.model_dump(by_alias=True) == {"f_name_s": "Mickey"}
@@ -364,7 +373,6 @@ class TestPlainAndSerializationAndValidationAlias:
         assert model.model_dump(by_alias=True) != {"f_name_a": "Mickey"}
         assert model.model_dump_json(by_alias=True) != '{"f_name_a":"Mickey"}'
 
-
     def test_should_repr_by_field_name(self, model_with_plain_and_serialization_and_validation_alias):
         model = model_with_plain_and_serialization_and_validation_alias(firstName="Mickey")
         assert repr(model).find("first_name") > -1
@@ -373,21 +381,11 @@ class TestPlainAndSerializationAndValidationAlias:
         assert repr(model).find("firstName") == -1
         assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
 
-
     @pytest.mark.parametrize(
-        "arg_name, expected",
-        [
-            ("first_name", True),
-            ("f_name_a", False),
-            ("f_name_s", False),
-            ("firstName", False)
-        ]
+        "arg_name, expected", [("first_name", True), ("f_name_a", False), ("f_name_s", False), ("firstName", False)]
     )
     def test_should_class_attribute_have_field_name(
-        self,
-        model_with_plain_and_serialization_and_validation_alias,
-        arg_name: str,
-        expected: bool
+        self, model_with_plain_and_serialization_and_validation_alias, arg_name: str, expected: bool
     ):
         model = model_with_plain_and_serialization_and_validation_alias(firstName="Mickey")
         assert hasattr(model, arg_name) is expected

--- a/tests/aliasing/test_combination_aliases.py
+++ b/tests/aliasing/test_combination_aliases.py
@@ -1,0 +1,394 @@
+from contextlib import AbstractContextManager as ContextManager
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+from pydantic import ValidationError
+
+
+class TestPlainAndSerializationAlias:
+    @pytest.mark.parametrize(
+        "arg_name, arg_value, expectation, expected_error",
+        [
+            ("firstName", "Mickey", does_not_raise(), None),
+            (
+                "f_name",
+                "Mickey",
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'f_name': 'Mickey'}}],
+            ),
+            (
+                "first_name",
+                "Mickey",
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'first_name': 'Mickey'}}],
+            )
+        ]
+    )
+    def test_should_instantiate_model_fields_by_plain_alias(
+        self,
+        model_with_plain_and_serialization_alias,
+        arg_name: str,
+        arg_value: str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            _ = model_with_plain_and_serialization_alias(**{arg_name: arg_value})
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    @pytest.mark.parametrize(
+        "data, expectation, expected_error",
+        [
+            ({"firstName": "Mickey"}, does_not_raise(), None),
+            ('{"firstName": "Mickey"}', does_not_raise(), None),
+            (
+                {"f_name": "Mickey"},
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+            ),
+            (
+                '{"f_name": "Mickey"}',
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+            ),
+            (
+                {"first_name": "Mickey"},
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'first_name': 'Mickey'}}]
+            ),
+            (
+                '{"first_name": "Mickey"}',
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'first_name': 'Mickey'}}]
+            ),
+        ]
+    )
+    def test_should_deserialize_by_plain_alias(
+        self,
+        model_with_plain_and_serialization_alias,
+        data: dict | str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            if isinstance(data, dict):
+                _ = model_with_plain_and_serialization_alias.model_validate(data)
+            else:
+                _ = model_with_plain_and_serialization_alias.model_validate_json(data)
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    def test_serialize_by_field_name(self, model_with_plain_and_serialization_alias):
+        model = model_with_plain_and_serialization_alias(firstName="Mickey")
+        assert model.model_dump() == {"first_name": "Mickey"}
+        assert model.model_dump_json() == '{"first_name":"Mickey"}'
+        assert model.model_dump() != {"f_name": "Mickey"}
+        assert model.model_dump_json() != '{"f_name":"Mickey"}'
+        assert model.model_dump() != {"firstName": "Mickey"}
+        assert model.model_dump_json() != '{"firstName":"Mickey"}'
+
+
+    def test_serialize_by_serialization_alias(self, model_with_plain_and_serialization_alias):
+        model = model_with_plain_and_serialization_alias(firstName="Mickey")
+        assert model.model_dump(by_alias=True) == {"f_name": "Mickey"}
+        assert model.model_dump_json(by_alias=True) == '{"f_name":"Mickey"}'
+        assert model.model_dump(by_alias=True) != {"first_name": "Mickey"}
+        assert model.model_dump_json(by_alias=True) != '{"first_name":"Mickey"}'
+        assert model.model_dump(by_alias=True) != {"firstName": "Mickey"}
+        assert model.model_dump_json(by_alias=True) != '{"firstName":"Mickey"}'
+
+
+    def test_should_repr_by_field_name(self, model_with_plain_and_serialization_alias):
+        model = model_with_plain_and_serialization_alias(firstName="Mickey")
+        assert repr(model).find("first_name") > -1
+        assert repr(model).find("f_name") == -1
+        assert repr(model).find("firstName") == -1
+        assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
+
+
+    @pytest.mark.parametrize(
+        "arg_name, expected",
+        [
+            ("first_name", True),
+            ("f_name", False),
+            ("firstName", False)
+        ]
+    )
+    def test_should_class_attribute_have_field_name(
+        self,
+        model_with_plain_and_serialization_alias,
+        arg_name: str,
+        expected: bool
+    ):
+        model = model_with_plain_and_serialization_alias(firstName="Mickey")
+        assert hasattr(model, arg_name) is expected
+        assert (arg_name in dict(model)) is expected
+
+
+class TestPlainAndValidationAlias:
+    @pytest.mark.parametrize(
+        "arg_name, arg_value, expectation, expected_error",
+        [
+            ("firstName", "Mickey", does_not_raise(), None),
+            (
+                "f_name",
+                "Mickey",
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'f_name': 'Mickey'}}],
+            ),
+            (
+                "first_name",
+                "Mickey",
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'first_name': 'Mickey'}}],
+            )
+        ]
+    )
+    def test_should_instantiate_model_fields_by_validation_alias(
+        self,
+        model_with_plain_and_validation_alias,
+        arg_name: str,
+        arg_value: str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            _ = model_with_plain_and_validation_alias(**{arg_name: arg_value})
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    @pytest.mark.parametrize(
+        "data, expectation, expected_error",
+        [
+            ({"firstName": "Mickey"}, does_not_raise(), None),
+            ('{"firstName": "Mickey"}', does_not_raise(), None),
+            (
+                {"f_name": "Mickey"},
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+            ),
+            (
+                '{"f_name": "Mickey"}',
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+            ),
+            (
+                {"first_name": "Mickey"},
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'first_name': 'Mickey'}}]
+            ),
+            (
+                '{"first_name": "Mickey"}',
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'first_name': 'Mickey'}}]
+            ),
+        ]
+    )
+    def test_should_deserialize_by_validation_alias(
+        self,
+        model_with_plain_and_validation_alias,
+        data: dict | str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            if isinstance(data, dict):
+                _ = model_with_plain_and_validation_alias.model_validate(data)
+            else:
+                _ = model_with_plain_and_validation_alias.model_validate_json(data)
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    def test_serialize_by_field_name(self, model_with_plain_and_validation_alias):
+        model = model_with_plain_and_validation_alias(firstName="Mickey")
+        assert model.model_dump() == {"first_name": "Mickey"}
+        assert model.model_dump_json() == '{"first_name":"Mickey"}'
+        assert model.model_dump() != {"f_name": "Mickey"}
+        assert model.model_dump_json() != '{"f_name":"Mickey"}'
+        assert model.model_dump() != {"firstName": "Mickey"}
+        assert model.model_dump_json() != '{"firstName":"Mickey"}'
+
+
+    def test_serialize_by_serialization_alias(self, model_with_plain_and_validation_alias):
+        model = model_with_plain_and_validation_alias(firstName="Mickey")
+        assert model.model_dump(by_alias=True) == {"f_name": "Mickey"}
+        assert model.model_dump_json(by_alias=True) == '{"f_name":"Mickey"}'
+        assert model.model_dump(by_alias=True) != {"firstName": "Mickey"}
+        assert model.model_dump_json(by_alias=True) != '{"firstName":"Mickey"}'
+
+
+    def test_should_repr_by_field_name(self, model_with_plain_and_validation_alias):
+        model = model_with_plain_and_validation_alias(firstName="Mickey")
+        assert repr(model).find("first_name") > -1
+        assert repr(model).find("f_name") == -1
+        assert repr(model).find("firstName") == -1
+        assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
+
+
+    @pytest.mark.parametrize(
+        "arg_name, expected",
+        [
+            ("first_name", True),
+            ("f_name", False),
+            ("firstName", False)
+        ]
+    )
+    def test_should_class_attribute_have_field_name(
+        self,
+        model_with_plain_and_validation_alias,
+        arg_name: str,
+        expected: bool
+    ):
+        model = model_with_plain_and_validation_alias(firstName="Mickey")
+        assert hasattr(model, arg_name) is expected
+        assert (arg_name in dict(model)) is expected
+
+
+class TestPlainAndSerializationAndValidationAlias:
+    @pytest.mark.parametrize(
+        "arg_name, arg_value, expectation, expected_error",
+        [
+            ("firstName", "Mickey", does_not_raise(), None),
+            (
+                "f_name_a",
+                "Mickey",
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'f_name_a': 'Mickey'}}],
+            ),
+            (
+                "f_name_s",
+                "Mickey",
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'f_name_s': 'Mickey'}}],
+            )
+        ]
+    )
+    def test_should_instantiate_model_fields_by_validation_alias(
+        self,
+        model_with_plain_and_serialization_and_validation_alias,
+        arg_name: str,
+        arg_value: str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            _ = model_with_plain_and_serialization_and_validation_alias(**{arg_name: arg_value})
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    @pytest.mark.parametrize(
+        "data, expectation, expected_error",
+        [
+            ({"firstName": "Mickey"}, does_not_raise(), None),
+            ('{"firstName": "Mickey"}', does_not_raise(), None),
+            (
+                {"f_name_a": "Mickey"},
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name_a': 'Mickey'}}]
+            ),
+            (
+                '{"f_name_a": "Mickey"}',
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name_a': 'Mickey'}}]
+            ),
+            (
+                {"f_name_s": "Mickey"},
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name_s': 'Mickey'}}]
+            ),
+            (
+                '{"f_name_s": "Mickey"}',
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name_s': 'Mickey'}}]
+            ),
+        ]
+    )
+    def test_should_deserialize_by_validation_alias(
+        self,
+        model_with_plain_and_serialization_and_validation_alias,
+        data: dict | str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            if isinstance(data, dict):
+                _ = model_with_plain_and_serialization_and_validation_alias.model_validate(data)
+            else:
+                _ = model_with_plain_and_serialization_and_validation_alias.model_validate_json(data)
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    def test_serialize_by_field_name(self, model_with_plain_and_serialization_and_validation_alias):
+        model = model_with_plain_and_serialization_and_validation_alias(firstName="Mickey")
+        assert model.model_dump() == {"first_name": "Mickey"}
+        assert model.model_dump_json() == '{"first_name":"Mickey"}'
+        assert model.model_dump() != {"f_name_a": "Mickey"}
+        assert model.model_dump_json() != '{"f_name_a":"Mickey"}'
+        assert model.model_dump() != {"f_name_s": "Mickey"}
+        assert model.model_dump_json() != '{"f_name_s":"Mickey"}'
+        assert model.model_dump() != {"firstName": "Mickey"}
+        assert model.model_dump_json() != '{"firstName":"Mickey"}'
+
+
+    def test_serialize_by_serialization_alias(self, model_with_plain_and_serialization_and_validation_alias):
+        model = model_with_plain_and_serialization_and_validation_alias(firstName="Mickey")
+        assert model.model_dump(by_alias=True) == {"f_name_s": "Mickey"}
+        assert model.model_dump_json(by_alias=True) == '{"f_name_s":"Mickey"}'
+        assert model.model_dump(by_alias=True) != {"firstName": "Mickey"}
+        assert model.model_dump_json(by_alias=True) != '{"firstName":"Mickey"}'
+        assert model.model_dump(by_alias=True) != {"f_name_a": "Mickey"}
+        assert model.model_dump_json(by_alias=True) != '{"f_name_a":"Mickey"}'
+
+
+    def test_should_repr_by_field_name(self, model_with_plain_and_serialization_and_validation_alias):
+        model = model_with_plain_and_serialization_and_validation_alias(firstName="Mickey")
+        assert repr(model).find("first_name") > -1
+        assert repr(model).find("f_name_a") == -1
+        assert repr(model).find("f_name_s") == -1
+        assert repr(model).find("firstName") == -1
+        assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
+
+
+    @pytest.mark.parametrize(
+        "arg_name, expected",
+        [
+            ("first_name", True),
+            ("f_name_a", False),
+            ("f_name_s", False),
+            ("firstName", False)
+        ]
+    )
+    def test_should_class_attribute_have_field_name(
+        self,
+        model_with_plain_and_serialization_and_validation_alias,
+        arg_name: str,
+        expected: bool
+    ):
+        model = model_with_plain_and_serialization_and_validation_alias(firstName="Mickey")
+        assert hasattr(model, arg_name) is expected
+        assert (arg_name in dict(model)) is expected

--- a/tests/aliasing/test_plain_alias.py
+++ b/tests/aliasing/test_plain_alias.py
@@ -14,15 +14,22 @@ class TestPlainAlias:
                 "first_name",
                 "Mickey",
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'first_name': 'Mickey'}}],
+                [
+                    {
+                        "type": "missing",
+                        "loc": ("firstName",),
+                        "msg": "Field required",
+                        "input": {"first_name": "Mickey"},
+                    }
+                ],
             ),
             (
                 "FirstName",
                 "Mickey",
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'FirstName': 'Mickey'}}],
-            )
-        ]
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"FirstName": "Mickey"}}],
+            ),
+        ],
     )
     def test_should_instantiate_model_fields_by_alias(
         self,
@@ -30,7 +37,7 @@ class TestPlainAlias:
         arg_name: str,
         arg_value: str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             _ = model_with_plain_alias(**{arg_name: arg_value})
@@ -40,7 +47,6 @@ class TestPlainAlias:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
 
-
     @pytest.mark.parametrize(
         "data, expectation, expected_error",
         [
@@ -49,21 +55,31 @@ class TestPlainAlias:
             (
                 {"first_name": "Mickey"},
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'first_name': 'Mickey'}}]
+                [
+                    {
+                        "type": "missing",
+                        "loc": ("firstName",),
+                        "msg": "Field required",
+                        "input": {"first_name": "Mickey"},
+                    }
+                ],
             ),
             (
                 '{"first_name": "Mickey"}',
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'first_name': 'Mickey'}}]
+                [
+                    {
+                        "type": "missing",
+                        "loc": ("firstName",),
+                        "msg": "Field required",
+                        "input": {"first_name": "Mickey"},
+                    }
+                ],
             ),
-        ]
+        ],
     )
     def test_should_deserialize_by_alias(
-        self,
-        model_with_plain_alias,
-        data: dict | str,
-        expectation: ContextManager,
-        expected_error: list[dict] | None
+        self, model_with_plain_alias, data: dict | str, expectation: ContextManager, expected_error: list[dict] | None
     ):
         with expectation as exc_info:
             if isinstance(data, dict):
@@ -76,14 +92,12 @@ class TestPlainAlias:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
 
-
     def test_serialize_by_field_name(self, model_with_plain_alias):
         model = model_with_plain_alias(firstName="Mickey")
         assert model.model_dump() == {"first_name": "Mickey"}
         assert model.model_dump_json() == '{"first_name":"Mickey"}'
         assert model.model_dump() != {"firstName": "Mickey"}
         assert model.model_dump_json() != '{"firstName":"Mickey"}'
-
 
     def test_serialize_by_alias(self, model_with_plain_alias):
         model = model_with_plain_alias(firstName="Mickey")
@@ -92,21 +106,13 @@ class TestPlainAlias:
         assert model.model_dump(by_alias=True) != {"first_name": "Mickey"}
         assert model.model_dump_json(by_alias=True) != '{"first_name":"Mickey"}'
 
-
     def test_should_repr_by_field_name(self, model_with_plain_alias):
         model = model_with_plain_alias(firstName="Mickey")
         assert repr(model).find("first_name") > -1
         assert repr(model).find("firstName") == -1
         assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
 
-
-    @pytest.mark.parametrize(
-        "arg_name, expected",
-        [
-            ("first_name", True),
-            ("firstName", False)
-        ]
-    )
+    @pytest.mark.parametrize("arg_name, expected", [("first_name", True), ("firstName", False)])
     def test_should_class_attribute_have_field_name(self, model_with_plain_alias, arg_name: str, expected: bool):
         model = model_with_plain_alias(firstName="Mickey")
         assert hasattr(model, arg_name) is expected
@@ -123,9 +129,9 @@ class TestPlainAliasPopByName:
                 "f_name",
                 "Mickey",
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'f_name': 'Mickey'}}],
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
-        ]
+        ],
     )
     def test_instantiate_model_fields_by_field_name_or_alias(
         self,
@@ -133,7 +139,7 @@ class TestPlainAliasPopByName:
         arg_name: str,
         arg_value: str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             _ = model_with_plain_alias_and_pop_by_name_config(**{arg_name: arg_value})
@@ -142,7 +148,6 @@ class TestPlainAliasPopByName:
         else:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
-
 
     @pytest.mark.parametrize(
         "data, expectation, expected_error",
@@ -154,21 +159,21 @@ class TestPlainAliasPopByName:
             (
                 {"f_name": "Mickey"},
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
             (
                 '{"f_name": "Mickey"}',
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
-        ]
+        ],
     )
     def test_deserialize_by_field_name_or_alias(
         self,
         model_with_plain_alias_and_pop_by_name_config,
         data: dict | str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             if isinstance(data, dict):
@@ -181,14 +186,12 @@ class TestPlainAliasPopByName:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
 
-
     def test_serialize_by_field_name(self, model_with_plain_alias_and_pop_by_name_config):
         model = model_with_plain_alias_and_pop_by_name_config(firstName="Mickey")
         assert model.model_dump() == {"first_name": "Mickey"}
         assert model.model_dump_json() == '{"first_name":"Mickey"}'
         assert model.model_dump() != {"firstName": "Mickey"}
         assert model.model_dump_json() != '{"firstName":"Mickey"}'
-
 
     def test_serialize_by_alias(self, model_with_plain_alias_and_pop_by_name_config):
         model = model_with_plain_alias_and_pop_by_name_config(firstName="Mickey")
@@ -197,26 +200,15 @@ class TestPlainAliasPopByName:
         assert model.model_dump(by_alias=True) != {"first_name": "Mickey"}
         assert model.model_dump_json(by_alias=True) != '{"first_name":"Mickey"}'
 
-
     def test_should_repr_by_field_name(self, model_with_plain_alias_and_pop_by_name_config):
         model = model_with_plain_alias_and_pop_by_name_config(firstName="Mickey")
         assert repr(model).find("first_name") > -1
         assert repr(model).find("firstName") == -1
         assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
 
-
-    @pytest.mark.parametrize(
-        "arg_name, expected",
-        [
-            ("first_name", True),
-            ("firstName", False)
-        ]
-    )
+    @pytest.mark.parametrize("arg_name, expected", [("first_name", True), ("firstName", False)])
     def test_should_class_attribute_have_field_name(
-        self,
-        model_with_plain_alias_and_pop_by_name_config,
-        arg_name: str,
-        expected: bool
+        self, model_with_plain_alias_and_pop_by_name_config, arg_name: str, expected: bool
     ):
         model = model_with_plain_alias_and_pop_by_name_config(firstName="Mickey")
         assert hasattr(model, arg_name) is expected

--- a/tests/aliasing/test_plain_alias.py
+++ b/tests/aliasing/test_plain_alias.py
@@ -1,0 +1,223 @@
+from contextlib import AbstractContextManager as ContextManager
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+from pydantic import ValidationError
+
+
+class TestPlainAlias:
+    @pytest.mark.parametrize(
+        "arg_name, arg_value, expectation, expected_error",
+        [
+            ("firstName", "Mickey", does_not_raise(), None),
+            (
+                "first_name",
+                "Mickey",
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'first_name': 'Mickey'}}],
+            ),
+            (
+                "FirstName",
+                "Mickey",
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'FirstName': 'Mickey'}}],
+            )
+        ]
+    )
+    def test_should_instantiate_model_fields_by_alias(
+        self,
+        model_with_plain_alias,
+        arg_name: str,
+        arg_value: str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            _ = model_with_plain_alias(**{arg_name: arg_value})
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    @pytest.mark.parametrize(
+        "data, expectation, expected_error",
+        [
+            ({"firstName": "Mickey"}, does_not_raise(), None),
+            ('{"firstName": "Mickey"}', does_not_raise(), None),
+            (
+                {"first_name": "Mickey"},
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'first_name': 'Mickey'}}]
+            ),
+            (
+                '{"first_name": "Mickey"}',
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'first_name': 'Mickey'}}]
+            ),
+        ]
+    )
+    def test_should_deserialize_by_alias(
+        self,
+        model_with_plain_alias,
+        data: dict | str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            if isinstance(data, dict):
+                _ = model_with_plain_alias.model_validate(data)
+            else:
+                _ = model_with_plain_alias.model_validate_json(data)
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    def test_serialize_by_field_name(self, model_with_plain_alias):
+        model = model_with_plain_alias(firstName="Mickey")
+        assert model.model_dump() == {"first_name": "Mickey"}
+        assert model.model_dump_json() == '{"first_name":"Mickey"}'
+        assert model.model_dump() != {"firstName": "Mickey"}
+        assert model.model_dump_json() != '{"firstName":"Mickey"}'
+
+
+    def test_serialize_by_alias(self, model_with_plain_alias):
+        model = model_with_plain_alias(firstName="Mickey")
+        assert model.model_dump(by_alias=True) == {"firstName": "Mickey"}
+        assert model.model_dump_json(by_alias=True) == '{"firstName":"Mickey"}'
+        assert model.model_dump(by_alias=True) != {"first_name": "Mickey"}
+        assert model.model_dump_json(by_alias=True) != '{"first_name":"Mickey"}'
+
+
+    def test_should_repr_by_field_name(self, model_with_plain_alias):
+        model = model_with_plain_alias(firstName="Mickey")
+        assert repr(model).find("first_name") > -1
+        assert repr(model).find("firstName") == -1
+        assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
+
+
+    @pytest.mark.parametrize(
+        "arg_name, expected",
+        [
+            ("first_name", True),
+            ("firstName", False)
+        ]
+    )
+    def test_should_class_attribute_have_field_name(self, model_with_plain_alias, arg_name: str, expected: bool):
+        model = model_with_plain_alias(firstName="Mickey")
+        assert hasattr(model, arg_name) is expected
+        assert (arg_name in dict(model)) is expected
+
+
+class TestPlainAliasPopByName:
+    @pytest.mark.parametrize(
+        "arg_name, arg_value, expectation, expected_error",
+        [
+            ("firstName", "Mickey", does_not_raise(), None),
+            ("first_name", "Mickey", does_not_raise(), None),
+            (
+                "f_name",
+                "Mickey",
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'f_name': 'Mickey'}}],
+            ),
+        ]
+    )
+    def test_instantiate_model_fields_by_field_name_or_alias(
+        self,
+        model_with_plain_alias_and_pop_by_name_config,
+        arg_name: str,
+        arg_value: str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            _ = model_with_plain_alias_and_pop_by_name_config(**{arg_name: arg_value})
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    @pytest.mark.parametrize(
+        "data, expectation, expected_error",
+        [
+            ({"firstName": "Mickey"}, does_not_raise(), None),
+            ('{"firstName": "Mickey"}', does_not_raise(), None),
+            ({"first_name": "Mickey"}, does_not_raise(), None),
+            ('{"first_name": "Mickey"}', does_not_raise(), None),
+            (
+                {"f_name": "Mickey"},
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+            ),
+            (
+                '{"f_name": "Mickey"}',
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+            ),
+        ]
+    )
+    def test_deserialize_by_field_name_or_alias(
+        self,
+        model_with_plain_alias_and_pop_by_name_config,
+        data: dict | str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            if isinstance(data, dict):
+                _ = model_with_plain_alias_and_pop_by_name_config.model_validate(data)
+            else:
+                _ = model_with_plain_alias_and_pop_by_name_config.model_validate_json(data)
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    def test_serialize_by_field_name(self, model_with_plain_alias_and_pop_by_name_config):
+        model = model_with_plain_alias_and_pop_by_name_config(firstName="Mickey")
+        assert model.model_dump() == {"first_name": "Mickey"}
+        assert model.model_dump_json() == '{"first_name":"Mickey"}'
+        assert model.model_dump() != {"firstName": "Mickey"}
+        assert model.model_dump_json() != '{"firstName":"Mickey"}'
+
+
+    def test_serialize_by_alias(self, model_with_plain_alias_and_pop_by_name_config):
+        model = model_with_plain_alias_and_pop_by_name_config(firstName="Mickey")
+        assert model.model_dump(by_alias=True) == {"firstName": "Mickey"}
+        assert model.model_dump_json(by_alias=True) == '{"firstName":"Mickey"}'
+        assert model.model_dump(by_alias=True) != {"first_name": "Mickey"}
+        assert model.model_dump_json(by_alias=True) != '{"first_name":"Mickey"}'
+
+
+    def test_should_repr_by_field_name(self, model_with_plain_alias_and_pop_by_name_config):
+        model = model_with_plain_alias_and_pop_by_name_config(firstName="Mickey")
+        assert repr(model).find("first_name") > -1
+        assert repr(model).find("firstName") == -1
+        assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
+
+
+    @pytest.mark.parametrize(
+        "arg_name, expected",
+        [
+            ("first_name", True),
+            ("firstName", False)
+        ]
+    )
+    def test_should_class_attribute_have_field_name(
+        self,
+        model_with_plain_alias_and_pop_by_name_config,
+        arg_name: str,
+        expected: bool
+    ):
+        model = model_with_plain_alias_and_pop_by_name_config(firstName="Mickey")
+        assert hasattr(model, arg_name) is expected
+        assert (arg_name in dict(model)) is expected

--- a/tests/aliasing/test_serialization_alias.py
+++ b/tests/aliasing/test_serialization_alias.py
@@ -14,15 +14,22 @@ class TestSerializationAlias:
                 "f_name",
                 "Mickey",
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('first_name',), 'msg': 'Field required','input': {'f_name': 'Mickey'}}],
+                [{"type": "missing", "loc": ("first_name",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
             (
                 "firstName",
                 "Mickey",
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('first_name',), 'msg': 'Field required','input': {'firstName': 'Mickey'}}],
-            )
-        ]
+                [
+                    {
+                        "type": "missing",
+                        "loc": ("first_name",),
+                        "msg": "Field required",
+                        "input": {"firstName": "Mickey"},
+                    }
+                ],
+            ),
+        ],
     )
     def test_should_instantiate_model_fields_by_field_name(
         self,
@@ -30,7 +37,7 @@ class TestSerializationAlias:
         arg_name: str,
         arg_value: str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             _ = model_with_serialization_alias(**{arg_name: arg_value})
@@ -40,7 +47,6 @@ class TestSerializationAlias:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
 
-
     @pytest.mark.parametrize(
         "data, expectation, expected_error",
         [
@@ -49,21 +55,21 @@ class TestSerializationAlias:
             (
                 {"f_name": "Mickey"},
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('first_name',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+                [{"type": "missing", "loc": ("first_name",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
             (
                 '{"f_name": "Mickey"}',
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('first_name',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+                [{"type": "missing", "loc": ("first_name",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
-        ]
+        ],
     )
     def test_should_deserialize_by_field_name(
         self,
         model_with_serialization_alias,
         data: dict | str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             if isinstance(data, dict):
@@ -76,14 +82,12 @@ class TestSerializationAlias:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
 
-
     def test_serialize_by_field_name(self, model_with_serialization_alias):
         model = model_with_serialization_alias(first_name="Mickey")
         assert model.model_dump() == {"first_name": "Mickey"}
         assert model.model_dump_json() == '{"first_name":"Mickey"}'
         assert model.model_dump() != {"f_name": "Mickey"}
         assert model.model_dump_json() != '{"f_name":"Mickey"}'
-
 
     def test_serialize_by_serialization_alias(self, model_with_serialization_alias):
         model = model_with_serialization_alias(first_name="Mickey")
@@ -92,22 +96,16 @@ class TestSerializationAlias:
         assert model.model_dump(by_alias=True) != {"first_name": "Mickey"}
         assert model.model_dump_json(by_alias=True) != '{"first_name":"Mickey"}'
 
-
     def test_should_repr_by_field_name(self, model_with_serialization_alias):
         model = model_with_serialization_alias(first_name="Mickey")
         assert repr(model).find("first_name") > -1
         assert repr(model).find("f_name") == -1
         assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
 
-
-    @pytest.mark.parametrize(
-        "arg_name, expected",
-        [
-            ("first_name", True),
-            ("f_name", False)
-        ]
-    )
-    def test_should_class_attribute_have_field_name(self, model_with_serialization_alias, arg_name: str, expected: bool):
+    @pytest.mark.parametrize("arg_name, expected", [("first_name", True), ("f_name", False)])
+    def test_should_class_attribute_have_field_name(
+        self, model_with_serialization_alias, arg_name: str, expected: bool
+    ):
         model = model_with_serialization_alias(first_name="Mickey")
         assert hasattr(model, arg_name) is expected
         assert (arg_name in dict(model)) is expected
@@ -122,9 +120,9 @@ class TestSerializationAliasPopByName:
                 "f_name",
                 "Mickey",
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('first_name',), 'msg': 'Field required','input': {'f_name': 'Mickey'}}],
+                [{"type": "missing", "loc": ("first_name",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
-        ]
+        ],
     )
     def test_should_instantiate_model_fields_by_field_name(
         self,
@@ -132,7 +130,7 @@ class TestSerializationAliasPopByName:
         arg_name: str,
         arg_value: str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             _ = model_with_serialization_alias_and_pop_by_name_config(**{arg_name: arg_value})
@@ -142,7 +140,6 @@ class TestSerializationAliasPopByName:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
 
-
     @pytest.mark.parametrize(
         "data, expectation, expected_error",
         [
@@ -151,21 +148,21 @@ class TestSerializationAliasPopByName:
             (
                 {"f_name": "Mickey"},
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('first_name',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+                [{"type": "missing", "loc": ("first_name",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
             (
                 '{"f_name": "Mickey"}',
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('first_name',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+                [{"type": "missing", "loc": ("first_name",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
-        ]
+        ],
     )
     def test_should_deserialize_by_field_name(
         self,
         model_with_serialization_alias_and_pop_by_name_config,
         data: dict | str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             if isinstance(data, dict):
@@ -178,14 +175,12 @@ class TestSerializationAliasPopByName:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
 
-
     def test_serialize_by_field_name(self, model_with_serialization_alias_and_pop_by_name_config):
         model = model_with_serialization_alias_and_pop_by_name_config(first_name="Mickey")
         assert model.model_dump() == {"first_name": "Mickey"}
         assert model.model_dump_json() == '{"first_name":"Mickey"}'
         assert model.model_dump() != {"f_name": "Mickey"}
         assert model.model_dump_json() != '{"f_name":"Mickey"}'
-
 
     def test_serialize_by_serialization_alias(self, model_with_serialization_alias_and_pop_by_name_config):
         model = model_with_serialization_alias_and_pop_by_name_config(first_name="Mickey")
@@ -194,26 +189,15 @@ class TestSerializationAliasPopByName:
         assert model.model_dump(by_alias=True) != {"first_name": "Mickey"}
         assert model.model_dump_json(by_alias=True) != '{"first_name":"Mickey"}'
 
-
     def test_should_repr_by_field_name(self, model_with_serialization_alias_and_pop_by_name_config):
         model = model_with_serialization_alias_and_pop_by_name_config(first_name="Mickey")
         assert repr(model).find("first_name") > -1
         assert repr(model).find("f_name") == -1
         assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
 
-
-    @pytest.mark.parametrize(
-        "arg_name, expected",
-        [
-            ("first_name", True),
-            ("f_name", False)
-        ]
-    )
+    @pytest.mark.parametrize("arg_name, expected", [("first_name", True), ("f_name", False)])
     def test_should_class_attribute_have_field_name(
-        self,
-        model_with_serialization_alias_and_pop_by_name_config,
-        arg_name: str,
-        expected: bool
+        self, model_with_serialization_alias_and_pop_by_name_config, arg_name: str, expected: bool
     ):
         model = model_with_serialization_alias_and_pop_by_name_config(first_name="Mickey")
         assert hasattr(model, arg_name) is expected

--- a/tests/aliasing/test_serialization_alias.py
+++ b/tests/aliasing/test_serialization_alias.py
@@ -1,0 +1,220 @@
+from contextlib import AbstractContextManager as ContextManager
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+from pydantic import ValidationError
+
+
+class TestSerializationAlias:
+    @pytest.mark.parametrize(
+        "arg_name, arg_value, expectation, expected_error",
+        [
+            ("first_name", "Mickey", does_not_raise(), None),
+            (
+                "f_name",
+                "Mickey",
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('first_name',), 'msg': 'Field required','input': {'f_name': 'Mickey'}}],
+            ),
+            (
+                "firstName",
+                "Mickey",
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('first_name',), 'msg': 'Field required','input': {'firstName': 'Mickey'}}],
+            )
+        ]
+    )
+    def test_should_instantiate_model_fields_by_field_name(
+        self,
+        model_with_serialization_alias,
+        arg_name: str,
+        arg_value: str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            _ = model_with_serialization_alias(**{arg_name: arg_value})
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    @pytest.mark.parametrize(
+        "data, expectation, expected_error",
+        [
+            ({"first_name": "Mickey"}, does_not_raise(), None),
+            ('{"first_name": "Mickey"}', does_not_raise(), None),
+            (
+                {"f_name": "Mickey"},
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('first_name',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+            ),
+            (
+                '{"f_name": "Mickey"}',
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('first_name',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+            ),
+        ]
+    )
+    def test_should_deserialize_by_field_name(
+        self,
+        model_with_serialization_alias,
+        data: dict | str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            if isinstance(data, dict):
+                _ = model_with_serialization_alias.model_validate(data)
+            else:
+                _ = model_with_serialization_alias.model_validate_json(data)
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    def test_serialize_by_field_name(self, model_with_serialization_alias):
+        model = model_with_serialization_alias(first_name="Mickey")
+        assert model.model_dump() == {"first_name": "Mickey"}
+        assert model.model_dump_json() == '{"first_name":"Mickey"}'
+        assert model.model_dump() != {"f_name": "Mickey"}
+        assert model.model_dump_json() != '{"f_name":"Mickey"}'
+
+
+    def test_serialize_by_serialization_alias(self, model_with_serialization_alias):
+        model = model_with_serialization_alias(first_name="Mickey")
+        assert model.model_dump(by_alias=True) == {"f_name": "Mickey"}
+        assert model.model_dump_json(by_alias=True) == '{"f_name":"Mickey"}'
+        assert model.model_dump(by_alias=True) != {"first_name": "Mickey"}
+        assert model.model_dump_json(by_alias=True) != '{"first_name":"Mickey"}'
+
+
+    def test_should_repr_by_field_name(self, model_with_serialization_alias):
+        model = model_with_serialization_alias(first_name="Mickey")
+        assert repr(model).find("first_name") > -1
+        assert repr(model).find("f_name") == -1
+        assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
+
+
+    @pytest.mark.parametrize(
+        "arg_name, expected",
+        [
+            ("first_name", True),
+            ("f_name", False)
+        ]
+    )
+    def test_should_class_attribute_have_field_name(self, model_with_serialization_alias, arg_name: str, expected: bool):
+        model = model_with_serialization_alias(first_name="Mickey")
+        assert hasattr(model, arg_name) is expected
+        assert (arg_name in dict(model)) is expected
+
+
+class TestSerializationAliasPopByName:
+    @pytest.mark.parametrize(
+        "arg_name, arg_value, expectation, expected_error",
+        [
+            ("first_name", "Mickey", does_not_raise(), None),
+            (
+                "f_name",
+                "Mickey",
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('first_name',), 'msg': 'Field required','input': {'f_name': 'Mickey'}}],
+            ),
+        ]
+    )
+    def test_should_instantiate_model_fields_by_field_name(
+        self,
+        model_with_serialization_alias_and_pop_by_name_config,
+        arg_name: str,
+        arg_value: str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            _ = model_with_serialization_alias_and_pop_by_name_config(**{arg_name: arg_value})
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    @pytest.mark.parametrize(
+        "data, expectation, expected_error",
+        [
+            ({"first_name": "Mickey"}, does_not_raise(), None),
+            ('{"first_name": "Mickey"}', does_not_raise(), None),
+            (
+                {"f_name": "Mickey"},
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('first_name',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+            ),
+            (
+                '{"f_name": "Mickey"}',
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('first_name',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+            ),
+        ]
+    )
+    def test_should_deserialize_by_field_name(
+        self,
+        model_with_serialization_alias_and_pop_by_name_config,
+        data: dict | str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            if isinstance(data, dict):
+                _ = model_with_serialization_alias_and_pop_by_name_config.model_validate(data)
+            else:
+                _ = model_with_serialization_alias_and_pop_by_name_config.model_validate_json(data)
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    def test_serialize_by_field_name(self, model_with_serialization_alias_and_pop_by_name_config):
+        model = model_with_serialization_alias_and_pop_by_name_config(first_name="Mickey")
+        assert model.model_dump() == {"first_name": "Mickey"}
+        assert model.model_dump_json() == '{"first_name":"Mickey"}'
+        assert model.model_dump() != {"f_name": "Mickey"}
+        assert model.model_dump_json() != '{"f_name":"Mickey"}'
+
+
+    def test_serialize_by_serialization_alias(self, model_with_serialization_alias_and_pop_by_name_config):
+        model = model_with_serialization_alias_and_pop_by_name_config(first_name="Mickey")
+        assert model.model_dump(by_alias=True) == {"f_name": "Mickey"}
+        assert model.model_dump_json(by_alias=True) == '{"f_name":"Mickey"}'
+        assert model.model_dump(by_alias=True) != {"first_name": "Mickey"}
+        assert model.model_dump_json(by_alias=True) != '{"first_name":"Mickey"}'
+
+
+    def test_should_repr_by_field_name(self, model_with_serialization_alias_and_pop_by_name_config):
+        model = model_with_serialization_alias_and_pop_by_name_config(first_name="Mickey")
+        assert repr(model).find("first_name") > -1
+        assert repr(model).find("f_name") == -1
+        assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
+
+
+    @pytest.mark.parametrize(
+        "arg_name, expected",
+        [
+            ("first_name", True),
+            ("f_name", False)
+        ]
+    )
+    def test_should_class_attribute_have_field_name(
+        self,
+        model_with_serialization_alias_and_pop_by_name_config,
+        arg_name: str,
+        expected: bool
+    ):
+        model = model_with_serialization_alias_and_pop_by_name_config(first_name="Mickey")
+        assert hasattr(model, arg_name) is expected
+        assert (arg_name in dict(model)) is expected

--- a/tests/aliasing/test_validation_alias.py
+++ b/tests/aliasing/test_validation_alias.py
@@ -14,9 +14,16 @@ class TestValidationAlias:
                 "first_name",
                 "Mickey",
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'first_name': 'Mickey'}}],
-            )
-        ]
+                [
+                    {
+                        "type": "missing",
+                        "loc": ("firstName",),
+                        "msg": "Field required",
+                        "input": {"first_name": "Mickey"},
+                    }
+                ],
+            ),
+        ],
     )
     def test_should_instantiate_model_fields_by_validation_alias(
         self,
@@ -24,7 +31,7 @@ class TestValidationAlias:
         arg_name: str,
         arg_value: str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             _ = model_with_validation_alias(**{arg_name: arg_value})
@@ -34,7 +41,6 @@ class TestValidationAlias:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
 
-
     @pytest.mark.parametrize(
         "data, expectation, expected_error",
         [
@@ -43,21 +49,35 @@ class TestValidationAlias:
             (
                 {"first_name": "Mickey"},
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'first_name': 'Mickey'}}]
+                [
+                    {
+                        "type": "missing",
+                        "loc": ("firstName",),
+                        "msg": "Field required",
+                        "input": {"first_name": "Mickey"},
+                    }
+                ],
             ),
             (
                 '{"first_name": "Mickey"}',
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'first_name': 'Mickey'}}]
+                [
+                    {
+                        "type": "missing",
+                        "loc": ("firstName",),
+                        "msg": "Field required",
+                        "input": {"first_name": "Mickey"},
+                    }
+                ],
             ),
-        ]
+        ],
     )
     def test_should_deserialize_by_validation_alias(
         self,
         model_with_validation_alias,
         data: dict | str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             if isinstance(data, dict):
@@ -70,7 +90,6 @@ class TestValidationAlias:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
 
-
     @pytest.mark.parametrize(
         "by_alias, method_choice, expected_value, unexpected_value",
         [
@@ -82,7 +101,7 @@ class TestValidationAlias:
             (True, "dump_json", '{"first_name":"Mickey"}', None),
             (False, "dump_json", None, '{"firstName":"Mickey"}'),
             (True, "dump_json", None, '{"firstName":"Mickey"}'),
-        ]
+        ],
     )
     def test_should_serialize_by_field_name(
         self,
@@ -104,31 +123,17 @@ class TestValidationAlias:
             else:
                 assert model.model_dump_json(by_alias=by_alias) != unexpected_value
 
-
     def test_should_repr_by_field_name(self, model_with_validation_alias):
         model = model_with_validation_alias(firstName="Mickey")
         assert repr(model).find("first_name") > -1
         assert repr(model).find("firstName") == -1
         assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
 
-
-    @pytest.mark.parametrize(
-        "arg_name, expected",
-        [
-            ("first_name", True),
-            ("firstName", False)
-        ]
-    )
-    def test_should_class_attribute_have_field_name(
-        self,
-        model_with_validation_alias,
-        arg_name: str,
-        expected: bool
-    ):
+    @pytest.mark.parametrize("arg_name, expected", [("first_name", True), ("firstName", False)])
+    def test_should_class_attribute_have_field_name(self, model_with_validation_alias, arg_name: str, expected: bool):
         model = model_with_validation_alias(firstName="Mickey")
         assert hasattr(model, arg_name) is expected
         assert (arg_name in dict(model)) is expected
-
 
     def test_alias_choices(self, model_with_validation_alias_choices):
         pass
@@ -144,9 +149,9 @@ class TestValidationAliasPopByName:
                 "f_name",
                 "Mickey",
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'f_name': 'Mickey'}}],
-            )
-        ]
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
+            ),
+        ],
     )
     def test_instantiate_model_fields_by_field_name_or_validation_alias(
         self,
@@ -154,7 +159,7 @@ class TestValidationAliasPopByName:
         arg_name: str,
         arg_value: str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             _ = model_with_validation_alias_and_pop_by_name_config(**{arg_name: arg_value})
@@ -163,7 +168,6 @@ class TestValidationAliasPopByName:
         else:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
-
 
     @pytest.mark.parametrize(
         "data, expectation, expected_error",
@@ -175,21 +179,21 @@ class TestValidationAliasPopByName:
             (
                 {"f_name": "Mickey"},
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
             (
                 '{"f_name": "Mickey"}',
                 pytest.raises(ValidationError),
-                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+                [{"type": "missing", "loc": ("firstName",), "msg": "Field required", "input": {"f_name": "Mickey"}}],
             ),
-        ]
+        ],
     )
     def test_deserialize_by_field_name_or_validation_alias(
         self,
         model_with_validation_alias_and_pop_by_name_config,
         data: dict | str,
         expectation: ContextManager,
-        expected_error: list[dict] | None
+        expected_error: list[dict] | None,
     ):
         with expectation as exc_info:
             if isinstance(data, dict):
@@ -202,7 +206,6 @@ class TestValidationAliasPopByName:
             assert exc_info is not None
             assert exc_info.value.errors(include_url=False) == expected_error
 
-
     @pytest.mark.parametrize(
         "by_alias, method_choice, expected_value, unexpected_value",
         [
@@ -214,7 +217,7 @@ class TestValidationAliasPopByName:
             (True, "dump_json", '{"first_name":"Mickey"}', None),
             (False, "dump_json", None, '{"firstName":"Mickey"}'),
             (True, "dump_json", None, '{"firstName":"Mickey"}'),
-        ]
+        ],
     )
     def test_should_serialize_by_field_name(
         self,
@@ -236,26 +239,15 @@ class TestValidationAliasPopByName:
             else:
                 assert model.model_dump_json(by_alias=by_alias) != unexpected_value
 
-
     def test_should_repr_by_field_name(self, model_with_validation_alias_and_pop_by_name_config):
         model = model_with_validation_alias_and_pop_by_name_config(firstName="Mickey")
         assert repr(model).find("first_name") > -1
         assert repr(model).find("firstName") == -1
         assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
 
-
-    @pytest.mark.parametrize(
-        "arg_name, expected",
-        [
-            ("first_name", True),
-            ("firstName", False)
-        ]
-    )
+    @pytest.mark.parametrize("arg_name, expected", [("first_name", True), ("firstName", False)])
     def test_should_class_attribute_have_field_name(
-        self,
-        model_with_validation_alias_and_pop_by_name_config,
-        arg_name: str,
-        expected: bool
+        self, model_with_validation_alias_and_pop_by_name_config, arg_name: str, expected: bool
     ):
         model = model_with_validation_alias_and_pop_by_name_config(firstName="Mickey")
         assert hasattr(model, arg_name) is expected

--- a/tests/aliasing/test_validation_alias.py
+++ b/tests/aliasing/test_validation_alias.py
@@ -1,0 +1,262 @@
+from contextlib import AbstractContextManager as ContextManager
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+from pydantic import ValidationError
+
+
+class TestValidationAlias:
+    @pytest.mark.parametrize(
+        "arg_name, arg_value, expectation, expected_error",
+        [
+            ("firstName", "Mickey", does_not_raise(), None),
+            (
+                "first_name",
+                "Mickey",
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'first_name': 'Mickey'}}],
+            )
+        ]
+    )
+    def test_should_instantiate_model_fields_by_validation_alias(
+        self,
+        model_with_validation_alias,
+        arg_name: str,
+        arg_value: str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            _ = model_with_validation_alias(**{arg_name: arg_value})
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    @pytest.mark.parametrize(
+        "data, expectation, expected_error",
+        [
+            ({"firstName": "Mickey"}, does_not_raise(), None),
+            ('{"firstName": "Mickey"}', does_not_raise(), None),
+            (
+                {"first_name": "Mickey"},
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'first_name': 'Mickey'}}]
+            ),
+            (
+                '{"first_name": "Mickey"}',
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'first_name': 'Mickey'}}]
+            ),
+        ]
+    )
+    def test_should_deserialize_by_validation_alias(
+        self,
+        model_with_validation_alias,
+        data: dict | str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            if isinstance(data, dict):
+                _ = model_with_validation_alias.model_validate(data)
+            else:
+                _ = model_with_validation_alias.model_validate_json(data)
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    @pytest.mark.parametrize(
+        "by_alias, method_choice, expected_value, unexpected_value",
+        [
+            (False, "dump", {"first_name": "Mickey"}, None),
+            (True, "dump", {"first_name": "Mickey"}, None),
+            (False, "dump", None, {"firstName": "Mickey"}),
+            (True, "dump", None, {"firstName": "Mickey"}),
+            (False, "dump_json", '{"first_name":"Mickey"}', None),
+            (True, "dump_json", '{"first_name":"Mickey"}', None),
+            (False, "dump_json", None, '{"firstName":"Mickey"}'),
+            (True, "dump_json", None, '{"firstName":"Mickey"}'),
+        ]
+    )
+    def test_should_serialize_by_field_name(
+        self,
+        model_with_validation_alias,
+        by_alias: bool,
+        method_choice: str,
+        expected_value: dict | str | None,
+        unexpected_value: dict | str | None,
+    ):
+        model = model_with_validation_alias(firstName="Mickey")
+        if method_choice == "dump":
+            if expected_value is not None:
+                assert model.model_dump(by_alias=by_alias) == expected_value
+            else:
+                assert model.model_dump(by_alias=by_alias) != unexpected_value
+        else:
+            if expected_value is not None:
+                assert model.model_dump_json(by_alias=by_alias) == expected_value
+            else:
+                assert model.model_dump_json(by_alias=by_alias) != unexpected_value
+
+
+    def test_should_repr_by_field_name(self, model_with_validation_alias):
+        model = model_with_validation_alias(firstName="Mickey")
+        assert repr(model).find("first_name") > -1
+        assert repr(model).find("firstName") == -1
+        assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
+
+
+    @pytest.mark.parametrize(
+        "arg_name, expected",
+        [
+            ("first_name", True),
+            ("firstName", False)
+        ]
+    )
+    def test_should_class_attribute_have_field_name(
+        self,
+        model_with_validation_alias,
+        arg_name: str,
+        expected: bool
+    ):
+        model = model_with_validation_alias(firstName="Mickey")
+        assert hasattr(model, arg_name) is expected
+        assert (arg_name in dict(model)) is expected
+
+
+    def test_alias_choices(self, model_with_validation_alias_choices):
+        pass
+
+
+class TestValidationAliasPopByName:
+    @pytest.mark.parametrize(
+        "arg_name, arg_value, expectation, expected_error",
+        [
+            ("firstName", "Mickey", does_not_raise(), None),
+            ("first_name", "Mickey", does_not_raise(), None),
+            (
+                "f_name",
+                "Mickey",
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required','input': {'f_name': 'Mickey'}}],
+            )
+        ]
+    )
+    def test_instantiate_model_fields_by_field_name_or_validation_alias(
+        self,
+        model_with_validation_alias_and_pop_by_name_config,
+        arg_name: str,
+        arg_value: str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            _ = model_with_validation_alias_and_pop_by_name_config(**{arg_name: arg_value})
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    @pytest.mark.parametrize(
+        "data, expectation, expected_error",
+        [
+            ({"firstName": "Mickey"}, does_not_raise(), None),
+            ('{"firstName": "Mickey"}', does_not_raise(), None),
+            ({"first_name": "Mickey"}, does_not_raise(), None),
+            ('{"first_name": "Mickey"}', does_not_raise(), None),
+            (
+                {"f_name": "Mickey"},
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+            ),
+            (
+                '{"f_name": "Mickey"}',
+                pytest.raises(ValidationError),
+                [{'type': 'missing', 'loc': ('firstName',), 'msg': 'Field required', 'input': {'f_name': 'Mickey'}}]
+            ),
+        ]
+    )
+    def test_deserialize_by_field_name_or_validation_alias(
+        self,
+        model_with_validation_alias_and_pop_by_name_config,
+        data: dict | str,
+        expectation: ContextManager,
+        expected_error: list[dict] | None
+    ):
+        with expectation as exc_info:
+            if isinstance(data, dict):
+                _ = model_with_validation_alias_and_pop_by_name_config.model_validate(data)
+            else:
+                _ = model_with_validation_alias_and_pop_by_name_config.model_validate_json(data)
+        if expected_error is None:
+            assert exc_info is None
+        else:
+            assert exc_info is not None
+            assert exc_info.value.errors(include_url=False) == expected_error
+
+
+    @pytest.mark.parametrize(
+        "by_alias, method_choice, expected_value, unexpected_value",
+        [
+            (False, "dump", {"first_name": "Mickey"}, None),
+            (True, "dump", {"first_name": "Mickey"}, None),
+            (False, "dump", None, {"firstName": "Mickey"}),
+            (True, "dump", None, {"firstName": "Mickey"}),
+            (False, "dump_json", '{"first_name":"Mickey"}', None),
+            (True, "dump_json", '{"first_name":"Mickey"}', None),
+            (False, "dump_json", None, '{"firstName":"Mickey"}'),
+            (True, "dump_json", None, '{"firstName":"Mickey"}'),
+        ]
+    )
+    def test_should_serialize_by_field_name(
+        self,
+        model_with_validation_alias_and_pop_by_name_config,
+        by_alias: bool,
+        method_choice: str,
+        expected_value: dict | str | None,
+        unexpected_value: dict | str | None,
+    ):
+        model = model_with_validation_alias_and_pop_by_name_config(firstName="Mickey")
+        if method_choice == "dump":
+            if expected_value is not None:
+                assert model.model_dump(by_alias=by_alias) == expected_value
+            else:
+                assert model.model_dump(by_alias=by_alias) != unexpected_value
+        else:
+            if expected_value is not None:
+                assert model.model_dump_json(by_alias=by_alias) == expected_value
+            else:
+                assert model.model_dump_json(by_alias=by_alias) != unexpected_value
+
+
+    def test_should_repr_by_field_name(self, model_with_validation_alias_and_pop_by_name_config):
+        model = model_with_validation_alias_and_pop_by_name_config(firstName="Mickey")
+        assert repr(model).find("first_name") > -1
+        assert repr(model).find("firstName") == -1
+        assert list(model.__rich_repr__()) == [("first_name", "Mickey")]
+
+
+    @pytest.mark.parametrize(
+        "arg_name, expected",
+        [
+            ("first_name", True),
+            ("firstName", False)
+        ]
+    )
+    def test_should_class_attribute_have_field_name(
+        self,
+        model_with_validation_alias_and_pop_by_name_config,
+        arg_name: str,
+        expected: bool
+    ):
+        model = model_with_validation_alias_and_pop_by_name_config(firstName="Mickey")
+        assert hasattr(model, arg_name) is expected
+        assert (arg_name in dict(model)) is expected


### PR DESCRIPTION
Summary:
- 01f2fc8a119d93a022205f44e7dc0e9ec05b3325:
    - `tests/aliasing/conftest.py`: add fixtures
    - `tests/aliasing/test_combination_aliases.py`, `tests/aliasing/test_plain_alias.py`, `tests/aliasing/test_serialization_alias.py`, `tests/aliasing/test_validation_alias.py`: add tests for aliases; need to test further functionalities, though

- 7f8b0a278e69b9ead511859299d7c194b4cb6fc0:
    - `pyproject.toml`: momentaneously ignore `FBT001` ([boolean-type-hint-positional-argument](https://docs.astral.sh/ruff/rules/boolean-type-hint-positional-argument/)) `ruff` rule 
    - leftover: apply `ruff` formatting