### PR TITLE
feat: add gh action pipeline

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,0 +1,64 @@
+name: Lint, Test
+
+on:
+  push:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.10"
+  POETRY_VERSION: "1.6.1"
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Load cached venv if cache exists
+        id: cached-poetry-dependencies
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies if cache does not exist
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+
+      - name: Install project
+        run: poetry install --no-interaction
+
+      - name: Setup just
+        uses: taiki-e/install-action@just
+
+      - name: Enforce code style (Ruff)
+        run: just ruff-show-violations
+
+      - name: Verify code formatting (Ruff)
+        run: just ruff-format-check
+
+      - name: Run tests
+        run: just test

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Load cached venv if cache exists
         id: cached-poetry-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/justfile
+++ b/justfile
@@ -36,3 +36,7 @@ ruff-format-check:
   @poetry run ruff format --check .
 
 lint-and-format: ruff-fix ruff-format
+
+test:
+  @echo "🚀 Testing code with pytest"
+  @poetry run pytest --verbose tests


### PR DESCRIPTION
Summary:
- 2e48c3be52d18abf007ce2c660b61ad49aeea6db:
    - `.github/workflows/actions.yaml`: add gh action pipeline for _linting_, _formatting_ and _testing_
- 5db499698350ae301734fd9a0c13b16e26600097:
    - `justfile`: add command to run tests
- 5f2546ebff278508b903d7f0125b5d4c60bfa901, c24da63f11efdf4a0c6718225d3b763a5ea19f0b:
    - `.github/workflows/actions.yaml`: update (relevant) action versions to get rid of the deprecation warning related to node.js 16 actions (see https://stackoverflow.com/questions/77897660/github-actions-node-js-16-actions-are-deprecated-warning and https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ as references)