### PR TITLE
feat: add remaining tests for alias

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
       - id: ruff-lint
         name: ruff (linter)
-        entry: just ruff
+        entry: just ruff .
         language: system
         types: [python]
       - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,11 +13,11 @@ repos:
     hooks:
       - id: ruff-lint
         name: ruff (linter)
-        entry: just ruff .
+        entry: poetry run ruff check .
         language: system
         types: [python]
       - id: ruff-format
         name: ruff (formatter)
-        entry: just ruff-format
+        entry: poetry run ruff format .
         language: system
         types: [python]

--- a/justfile
+++ b/justfile
@@ -15,25 +15,25 @@ check-project:
   @echo "🚀 Running the hooks against all files"
   @poetry run pre-commit run --all-files
 
-ruff file:
+ruff:
   @echo "🚀 Linting the project with Ruff"
-  @poetry run ruff check {{file}}
+  @poetry run ruff check .
 
 ruff-show-violations:
   @echo "🚀 Linting the project with Ruff and show violations"
-  @poetry run ruff check --output-format="grouped" tests
+  @poetry run ruff check --output-format="grouped" .
 
 ruff-fix:
   @echo "🚀 Linting the project with Ruff and autofix violations (where possible)"
-  @poetry run ruff check --fix tests
+  @poetry run ruff check --fix .
 
 ruff-format:
   @echo "🚀 Formatting the code with Ruff"
-  @poetry run ruff format tests
+  @poetry run ruff format .
 
 ruff-format-check:
   @echo "🚀 Listing files Ruff would reformat"
-  @poetry run ruff format --check tests
+  @poetry run ruff format --check .
 
 lint-and-format: ruff-fix ruff-format
 

--- a/justfile
+++ b/justfile
@@ -17,23 +17,23 @@ check-project:
 
 ruff:
   @echo "🚀 Linting the project with Ruff"
-  @poetry run ruff check .
+  @poetry run ruff check tests
 
 ruff-show-violations:
   @echo "🚀 Linting the project with Ruff and show violations"
-  @poetry run ruff check --output-format="grouped" .
+  @poetry run ruff check --output-format="grouped" tests
 
 ruff-fix:
   @echo "🚀 Linting the project with Ruff and autofix violations (where possible)"
-  @poetry run ruff check --fix .
+  @poetry run ruff check --fix tests
 
 ruff-format:
   @echo "🚀 Formatting the code with Ruff"
-  @poetry run ruff format .
+  @poetry run ruff format tests
 
 ruff-format-check:
   @echo "🚀 Listing files Ruff would reformat"
-  @poetry run ruff format --check .
+  @poetry run ruff format --check tests
 
 lint-and-format: ruff-fix ruff-format
 

--- a/justfile
+++ b/justfile
@@ -15,9 +15,9 @@ check-project:
   @echo "🚀 Running the hooks against all files"
   @poetry run pre-commit run --all-files
 
-ruff:
+ruff file:
   @echo "🚀 Linting the project with Ruff"
-  @poetry run ruff check tests
+  @poetry run ruff check {{file}}
 
 ruff-show-violations:
   @echo "🚀 Linting the project with Ruff and show violations"

--- a/tests/aliasing/conftest.py
+++ b/tests/aliasing/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic import AliasChoices, AliasGenerator, BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, AliasGenerator, AliasPath, BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel, to_pascal
 
 
@@ -38,7 +38,10 @@ def model_with_validation_alias_choices():
 @pytest.fixture
 def model_with_validation_alias_path():
     class ModelWithValidationAliasPath(BaseModel):
-        pass
+        first_name: str = Field(validation_alias=AliasPath("names", 0))
+        last_name: str = Field(validation_alias=AliasPath("names", 1))
+
+    return ModelWithValidationAliasPath
 
 
 @pytest.fixture

--- a/tests/aliasing/conftest.py
+++ b/tests/aliasing/conftest.py
@@ -1,5 +1,6 @@
 import pytest
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, AliasGenerator, BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel, to_pascal
 
 
 @pytest.fixture
@@ -89,3 +90,54 @@ def model_with_validation_alias_and_pop_by_name_config():
         first_name: str = Field(validation_alias="firstName")
 
     return ModelWithValidationAliasPopByName
+
+
+@pytest.fixture
+def model_with_alias_generator_and_unset_priority():
+    class ModelWithAliasGeneratorAndUnsetPriority(BaseModel):
+        model_config = ConfigDict(
+            alias_generator=AliasGenerator(
+                alias=to_camel,
+                validation_alias=lambda x: x.upper(),
+                serialization_alias=to_pascal,
+            )
+        )
+        first_name_pa: str = Field(alias="f_name_pa")
+        first_name_va: str = Field(validation_alias="f_name_va")
+        first_name_sa: str = Field(serialization_alias="f_name_sa")
+
+    return ModelWithAliasGeneratorAndUnsetPriority
+
+
+@pytest.fixture
+def model_with_alias_generator_and_priority_1():
+    class ModelWithAliasGeneratorAndAliasPriority1(BaseModel):
+        model_config = ConfigDict(
+            alias_generator=AliasGenerator(
+                alias=to_camel,
+                validation_alias=lambda x: x.upper(),
+                serialization_alias=to_pascal,
+            )
+        )
+        first_name_pa: str = Field(alias="f_name_pa", alias_priority=1)
+        first_name_va: str = Field(validation_alias="f_name_va", alias_priority=1)
+        first_name_sa: str = Field(serialization_alias="f_name_sa", alias_priority=1)
+
+    return ModelWithAliasGeneratorAndAliasPriority1
+
+
+@pytest.fixture
+def model_with_alias_generator_and_priority_2():
+    class ModelWithAliasGeneratorAndAliasPriority2(BaseModel):
+        model_config = ConfigDict(
+            alias_generator=AliasGenerator(
+                alias=to_camel,
+                validation_alias=lambda x: x.upper(),
+                serialization_alias=to_pascal,
+            )
+        )
+        first_name_pa: str = Field(alias="f_name_pa", alias_priority=2)
+        first_name_va: str = Field(validation_alias="f_name_va", alias_priority=2)
+        first_name_sa: str = Field(serialization_alias="f_name_sa", alias_priority=2)
+
+    return ModelWithAliasGeneratorAndAliasPriority2


### PR DESCRIPTION
Summary:
- e45bbfc177c04d0c4ff6eb4ac95b68bf95e36162, b7396e016a5a6b95463c2a3127576805be42699b, 493c0fde7fdcbaf84d6fbdbeed7479453453fcfe: attempts to further investigate the not working behaviour when referencing `just` commands in `.pre-commit-config.yaml`. I'm still not able to correctly interpret the answer from https://stackoverflow.com/questions/78243419/just-error-justfile-does-not-contain-recipes-when-pre-committing, nor any other solution I've tried does work; revert to using _"unrolled" poetry run_ commands in `.pre-commit-config.yaml`[^note]
- 3c2d72f8b3b4ce87273d56f7409098a88362ff74:
    - `tests/aliasing/conftest.py`: add fixtures to deal with `AliasGenerator` and `alias_priority` configs
    - `tests/aliasing/test_combination_aliases.py`: test `AliasGenerator` and `alias_priority` combinations
- 9ba22fbd44b3b5826690c75ff1abd4ce34c4065f:
    - `tests/aliasing/conftest.py`: add fixtures to deal with `AliasChoices` and `AliasPath`
    - `tests/aliasing/test_validation_alias.py`: test validation with `AliasChoices` and `AliasPath`

[^note]: must not be an issue solely pertaining to `just` though, but rather to referencing `just` commands in `.pre-commit-config.yaml`. Indeed, the same commands do work smoothly in `.github/workflows/actions.yaml`